### PR TITLE
Add Security Panel, Container Log Viewer, and extensible plugin architecture

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,4 @@ coverage.html
 # Release builds
 /releases/
 \n# Xcode\nxcuserdata/\n*.xcuserstate
+deskmon.xcodeproj/project.xcworkspace/xcuserdata/

--- a/deskmon/Plugins/ContainerPlugin.swift
+++ b/deskmon/Plugins/ContainerPlugin.swift
@@ -1,0 +1,28 @@
+import SwiftUI
+
+/// Context provided to a plugin when it renders its detail view.
+struct PluginContext {
+    /// The server on which this container is running.
+    let serverID: UUID
+    /// The Docker container the plugin is rendering.
+    let container: DockerContainer
+}
+
+/// A plugin that provides a custom detail view for a specific Docker container type.
+///
+/// To add a new plugin:
+/// 1. Create a type conforming to `ContainerPlugin`
+/// 2. Register it at startup: `PluginRegistry.shared.register(MyPlugin())`
+@MainActor
+protocol ContainerPlugin {
+    /// Unique stable identifier, e.g. `"n8n"`.
+    var id: String { get }
+
+    /// Return `true` if this plugin should handle a container with the given image name.
+    ///
+    /// The `imageName` passed here is normalised: lowercased with the tag (`:latest` etc.) stripped.
+    func matches(imageName: String) -> Bool
+
+    /// Build the SwiftUI view rendered below the standard container stats in the detail panel.
+    func makeDetailView(context: PluginContext) -> AnyView
+}

--- a/deskmon/Plugins/N8nPlugin/N8nClient.swift
+++ b/deskmon/Plugins/N8nPlugin/N8nClient.swift
@@ -1,0 +1,172 @@
+import Foundation
+
+// MARK: - Models
+
+struct N8nWorkflow: Codable, Identifiable {
+    let id: String
+    let name: String
+    let active: Bool
+    let updatedAt: String?
+    let isArchived: Bool?
+}
+
+struct N8nExecution: Codable, Identifiable {
+    let id: String
+    let finished: Bool
+    let mode: String
+    let status: String  // "success", "error", "crashed", "running", "waiting"
+    let startedAt: String?
+    let stoppedAt: String?
+    let workflowId: String?
+    let workflowData: WorkflowRef?
+
+    struct WorkflowRef: Codable {
+        let id: String
+        let name: String
+    }
+
+    var startedDate: Date? {
+        guard let s = startedAt else { return nil }
+        // n8n timestamps include milliseconds ("2024-01-01T10:00:00.000Z") which the
+        // default ISO8601DateFormatter doesn't handle — enable fractional seconds.
+        let fmt = ISO8601DateFormatter()
+        fmt.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        return fmt.date(from: s) ?? ISO8601DateFormatter().date(from: s)
+    }
+
+    var formattedStartTime: String {
+        guard let date = startedDate else { return "—" }
+        let df = DateFormatter()
+        df.dateFormat = Calendar.current.isDateInToday(date) ? "HH:mm" : "d MMM, HH:mm"
+        return df.string(from: date)
+    }
+}
+
+private struct N8nListResponse<T: Codable>: Codable {
+    let data: [T]
+    let nextCursor: String?
+}
+
+// Minimal workflow detail model — only used to find webhook trigger nodes.
+private struct N8nWorkflowDetail: Codable {
+    let nodes: [Node]
+
+    struct Node: Codable {
+        let type: String
+        let parameters: Parameters?
+        struct Parameters: Codable {
+            let path: String?
+            let httpMethod: String?
+        }
+    }
+
+    var webhookNode: Node? {
+        nodes.first { $0.type == "n8n-nodes-base.webhook" }
+    }
+}
+
+// MARK: - Client
+
+struct N8nClient {
+    let baseURL: String
+    let apiKey: String
+
+    private func makeRequest(path: String, method: String = "GET") throws -> URLRequest {
+        guard let url = URL(string: "\(baseURL)\(path)") else {
+            throw URLError(.badURL)
+        }
+        var req = URLRequest(url: url, timeoutInterval: 10)
+        req.httpMethod = method
+        req.setValue(apiKey, forHTTPHeaderField: "X-N8N-API-KEY")
+        req.setValue("application/json", forHTTPHeaderField: "Accept")
+        return req
+    }
+
+    func fetchWorkflows() async throws -> [N8nWorkflow] {
+        let req = try makeRequest(path: "/api/v1/workflows?limit=25")
+        let (data, response) = try await URLSession.shared.data(for: req)
+        if let http = response as? HTTPURLResponse { try checkStatus(http) }
+        let all = try JSONDecoder().decode(N8nListResponse<N8nWorkflow>.self, from: data).data
+        return all.filter { $0.isArchived != true }
+    }
+
+    func fetchExecutions(limit: Int = 10) async throws -> [N8nExecution] {
+        let req = try makeRequest(path: "/api/v1/executions?limit=\(limit)&includeData=false")
+        let (data, response) = try await URLSession.shared.data(for: req)
+        if let http = response as? HTTPURLResponse { try checkStatus(http) }
+        return try JSONDecoder().decode(N8nListResponse<N8nExecution>.self, from: data).data
+    }
+
+    func fetchRunningExecutions() async throws -> [N8nExecution] {
+        let req = try makeRequest(path: "/api/v1/executions?status=running&limit=10&includeData=false")
+        let (data, response) = try await URLSession.shared.data(for: req)
+        if let http = response as? HTTPURLResponse { try checkStatus(http) }
+        return try JSONDecoder().decode(N8nListResponse<N8nExecution>.self, from: data).data
+    }
+
+    /// Returns the webhook path and HTTP method for a workflow's Webhook trigger node,
+    /// or `nil` if the workflow has no webhook trigger.
+    func fetchWebhookInfo(workflowID: String) async throws -> (path: String, method: String)? {
+        let req = try makeRequest(path: "/api/v1/workflows/\(workflowID)")
+        let (data, response) = try await URLSession.shared.data(for: req)
+        if let http = response as? HTTPURLResponse { try checkStatus(http) }
+        let detail = try JSONDecoder().decode(N8nWorkflowDetail.self, from: data)
+        guard let node = detail.webhookNode,
+              let path = node.parameters?.path, !path.isEmpty else { return nil }
+        let method = node.parameters?.httpMethod ?? "GET"
+        return (path: path, method: method)
+    }
+
+    /// Trigger a workflow by POSTing to its webhook URL.
+    /// Note: no API key is sent — webhook endpoints use their own auth configured in n8n.
+    func triggerWebhook(path: String, method: String) async throws {
+        guard let url = URL(string: "\(baseURL)/webhook/\(path)") else {
+            throw URLError(.badURL)
+        }
+        var req = URLRequest(url: url, timeoutInterval: 10)
+        req.httpMethod = method
+        let (_, response) = try await URLSession.shared.data(for: req)
+        if let http = response as? HTTPURLResponse {
+            try checkStatus(http)
+        }
+    }
+
+    private func checkStatus(_ response: HTTPURLResponse) throws {
+        if response.statusCode == 401 { throw N8nError.unauthorized }
+        guard (200...299).contains(response.statusCode) else {
+            throw N8nError.httpError(response.statusCode)
+        }
+    }
+}
+
+// MARK: - Errors
+
+enum N8nError: LocalizedError {
+    case unauthorized
+    case httpError(Int)
+
+    var errorDescription: String? {
+        switch self {
+        case .unauthorized: "Invalid API key — check your n8n settings"
+        case .httpError(let code): "n8n returned HTTP \(code)"
+        }
+    }
+}
+
+// MARK: - Keychain
+
+extension KeychainStore {
+    static func saveN8nAPIKey(_ key: String, serverID: UUID) throws {
+        guard let data = key.data(using: .utf8) else { throw KeychainError.dataConversion }
+        try save(account: "n8n-apikey-\(serverID.uuidString)", data: data)
+    }
+
+    static func loadN8nAPIKey(serverID: UUID) -> String? {
+        guard let data = load(account: "n8n-apikey-\(serverID.uuidString)") else { return nil }
+        return String(data: data, encoding: .utf8)
+    }
+
+    static func deleteN8nAPIKey(serverID: UUID) {
+        delete(account: "n8n-apikey-\(serverID.uuidString)")
+    }
+}

--- a/deskmon/Plugins/N8nPlugin/N8nDetailView.swift
+++ b/deskmon/Plugins/N8nPlugin/N8nDetailView.swift
@@ -1,0 +1,471 @@
+import SwiftUI
+
+struct N8nDetailView: View {
+    let context: PluginContext
+
+    @Environment(ServerManager.self) private var serverManager
+
+    // API key setup
+    @State private var savedAPIKey: String?
+    @State private var apiKeyInput = ""
+    @State private var isSavingKey = false
+    @State private var keySetupError: String?
+
+    // Connection
+    @State private var client: N8nClient?
+    @State private var tunnelError: String?
+
+    // Data
+    @State private var workflows: [N8nWorkflow] = []
+    @State private var executions: [N8nExecution] = []
+    @State private var isLoading = false
+    @State private var loadError: String?
+
+    // Trigger
+    @State private var selectedTriggerID: String?
+    @State private var webhookInfo: (path: String, method: String)?
+    @State private var isLoadingWebhookInfo = false
+    @State private var isTriggering = false
+    @State private var triggerMessage: String?
+    @State private var showingTriggerInfo = false
+
+    private let n8nPort = 5678
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 14) {
+            if savedAPIKey == nil {
+                setupSection
+            } else if let error = tunnelError {
+                errorSection(error)
+            } else if let c = client {
+                dataSection(c)
+            } else {
+                HStack {
+                    ProgressView()
+                        .controlSize(.small)
+                    Text("Connecting to n8n…")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+                .frame(maxWidth: .infinity, alignment: .center)
+                .padding(.vertical, 8)
+                .cardStyle(cornerRadius: 10)
+                .padding(.vertical, 2)
+            }
+        }
+        .task {
+            await initialize()
+        }
+    }
+
+    // MARK: - Setup
+
+    private var setupSection: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Label("n8n", systemImage: "bolt.horizontal.fill")
+                .font(.caption.weight(.medium))
+                .foregroundStyle(.secondary)
+
+            Text("Enter your n8n API key to view workflow status.")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+
+            VStack(alignment: .leading, spacing: 4) {
+                Text("API Key")
+                    .font(.caption.weight(.medium))
+                    .foregroundStyle(.secondary)
+                SecureField("", text: $apiKeyInput, prompt: Text("n8n_api_…").foregroundStyle(.quaternary))
+                    .textFieldStyle(.roundedBorder)
+            }
+
+            if let error = keySetupError {
+                Text(error)
+                    .font(.caption2)
+                    .foregroundStyle(Theme.critical)
+            }
+
+            HStack {
+                Spacer()
+                Button {
+                    Task { await saveAPIKey() }
+                } label: {
+                    if isSavingKey {
+                        ProgressView().controlSize(.small).padding(.horizontal, 8)
+                    } else {
+                        Text("Connect")
+                    }
+                }
+                .buttonStyle(.darkProminent)
+                .disabled(apiKeyInput.trimmingCharacters(in: .whitespaces).isEmpty || isSavingKey)
+            }
+        }
+        .padding(12)
+        .cardStyle(cornerRadius: 10)
+    }
+
+    // MARK: - Error
+
+    private func errorSection(_ message: String) -> some View {
+        HStack(spacing: 6) {
+            Image(systemName: "exclamationmark.triangle.fill")
+                .foregroundStyle(Theme.warning)
+            Text(message)
+                .font(.caption)
+                .foregroundStyle(.secondary)
+        }
+        .padding(12)
+        .cardStyle(cornerRadius: 10)
+    }
+
+    // MARK: - Data
+
+    @ViewBuilder
+    private func dataSection(_ c: N8nClient) -> some View {
+        workflowsSection
+        triggerSection(c)
+        executionsSection
+    }
+
+    private var workflowsSection: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            HStack {
+                Label("Workflows", systemImage: "bolt.horizontal.fill")
+                    .font(.caption.weight(.medium))
+                    .foregroundStyle(.secondary)
+                Spacer()
+                if isLoading {
+                    ProgressView().controlSize(.mini)
+                } else {
+                    Button {
+                        if let c = client { Task { await loadData(with: c) } }
+                    } label: {
+                        Image(systemName: "arrow.clockwise")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    }
+                    .buttonStyle(.plain)
+                }
+            }
+
+            if let error = loadError {
+                Text(error)
+                    .font(.caption2)
+                    .foregroundStyle(Theme.critical)
+            } else if workflows.isEmpty && !isLoading {
+                Text("No workflows found")
+                    .font(.caption2)
+                    .foregroundStyle(.tertiary)
+            } else {
+                let active = workflows.filter(\.active)
+                Text("\(active.count) active / \(workflows.count) total")
+                    .font(.caption2.monospacedDigit())
+                    .foregroundStyle(.secondary)
+
+                VStack(spacing: 4) {
+                    ForEach(workflows.prefix(6)) { wf in
+                        HStack(spacing: 6) {
+                            Circle()
+                                .fill(wf.active ? Theme.healthy : Color.secondary.opacity(0.4))
+                                .frame(width: 6, height: 6)
+                            Text(wf.name)
+                                .font(.caption2)
+                                .lineLimit(1)
+                                .truncationMode(.tail)
+                            Spacer()
+                            Text(wf.active ? "active" : "inactive")
+                                .font(.caption2)
+                                .foregroundStyle(wf.active ? Theme.healthy : Color.secondary.opacity(0.5))
+                        }
+                    }
+                    if workflows.count > 6 {
+                        Text("+ \(workflows.count - 6) more")
+                            .font(.caption2)
+                            .foregroundStyle(.tertiary)
+                    }
+                }
+            }
+        }
+        .padding(12)
+        .cardStyle(cornerRadius: 10)
+    }
+
+    // Fallback name lookup for executions whose workflowData is nil.
+    private var workflowNameByID: [String: String] {
+        Dictionary(uniqueKeysWithValues: workflows.map { ($0.id, $0.name) })
+    }
+
+    private var executionsSection: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            HStack {
+                Label("Recent Executions", systemImage: "clock.arrow.2.circlepath")
+                    .font(.caption.weight(.medium))
+                    .foregroundStyle(.secondary)
+                Spacer()
+                if isLoading {
+                    ProgressView().controlSize(.mini)
+                } else {
+                    Button {
+                        if let c = client { Task { await loadData(with: c) } }
+                    } label: {
+                        Image(systemName: "arrow.clockwise")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    }
+                    .buttonStyle(.plain)
+                }
+            }
+
+            if executions.isEmpty && !isLoading {
+                Text("No recent executions")
+                    .font(.caption2)
+                    .foregroundStyle(.tertiary)
+            } else {
+                VStack(spacing: 6) {
+                    ForEach(executions.prefix(8)) { exec in
+                        let name = exec.workflowData?.name
+                            ?? workflowNameByID[exec.workflowId ?? ""]
+                            ?? exec.workflowId
+                            ?? "Unknown"
+                        HStack(spacing: 6) {
+                            Image(systemName: exec.statusIcon)
+                                .font(.caption2)
+                                .foregroundStyle(exec.statusColor)
+                                .frame(width: 14, alignment: .center)
+                            Text(name)
+                                .font(.caption2)
+                                .lineLimit(1)
+                                .truncationMode(.tail)
+                            Spacer(minLength: 4)
+                            Text("#\(exec.id) · \(exec.formattedStartTime)")
+                                .font(.caption2.monospacedDigit())
+                                .foregroundStyle(.tertiary)
+                                .fixedSize()
+                        }
+                    }
+                }
+            }
+        }
+        .padding(12)
+        .cardStyle(cornerRadius: 10)
+    }
+
+    private func triggerSection(_ c: N8nClient) -> some View {
+        VStack(alignment: .leading, spacing: 10) {
+            HStack(spacing: 6) {
+                Label("Trigger Workflow", systemImage: "play.circle")
+                    .font(.caption.weight(.medium))
+                    .foregroundStyle(.secondary)
+
+                Button {
+                    showingTriggerInfo = true
+                } label: {
+                    Image(systemName: "info.circle")
+                        .font(.caption)
+                        .foregroundStyle(.tertiary)
+                }
+                .buttonStyle(.plain)
+                .popover(isPresented: $showingTriggerInfo, arrowEdge: .top) {
+                    VStack(alignment: .leading, spacing: 8) {
+                        Label("Webhook Requirements", systemImage: "info.circle.fill")
+                            .font(.caption.weight(.semibold))
+                            .foregroundStyle(.primary)
+
+                        Text("For a workflow to be triggerable from here, it must have a **Webhook** trigger node configured with:")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+
+                        VStack(alignment: .leading, spacing: 4) {
+                            requirementRow("HTTP Method set to **POST**")
+                            requirementRow("Authentication set to **None**")
+                            requirementRow("The workflow must be **active**")
+                        }
+                    }
+                    .padding(14)
+                    .frame(width: 260)
+                    .preferredColorScheme(.dark)
+                }
+            }
+
+            if workflows.isEmpty {
+                Text("No workflows available")
+                    .font(.caption2)
+                    .foregroundStyle(.tertiary)
+            } else {
+                HStack(spacing: 8) {
+                    Picker("", selection: $selectedTriggerID) {
+                        Text("Select a workflow…").tag(nil as String?)
+                        ForEach(workflows) { wf in
+                            Text(wf.name).tag(wf.id as String?)
+                        }
+                    }
+                    .labelsHidden()
+                    .pickerStyle(.menu)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+
+                    if isLoadingWebhookInfo {
+                        ProgressView().controlSize(.small)
+                    } else {
+                        Button {
+                            Task { await triggerWorkflow(with: c) }
+                        } label: {
+                            if isTriggering {
+                                ProgressView().controlSize(.small).padding(.horizontal, 4)
+                            } else {
+                                Text("Run")
+                            }
+                        }
+                        .buttonStyle(.darkProminent)
+                        .disabled(webhookInfo == nil || isTriggering)
+                        .fixedSize()
+                    }
+                }
+
+                if selectedTriggerID != nil && !isLoadingWebhookInfo && webhookInfo == nil {
+                    Text("This workflow has no Webhook trigger node")
+                        .font(.caption2)
+                        .foregroundStyle(.tertiary)
+                }
+            }
+
+            if let msg = triggerMessage {
+                Text(msg)
+                    .font(.caption2)
+                    .foregroundStyle(msg.hasPrefix("Error") ? Theme.critical : Theme.healthy)
+            }
+        }
+        .padding(12)
+        .cardStyle(cornerRadius: 10)
+        .onChange(of: selectedTriggerID) { _, newID in
+            webhookInfo = nil
+            triggerMessage = nil
+            guard let id = newID else { return }
+            Task { await loadWebhookInfo(for: id, client: c) }
+        }
+    }
+
+    // MARK: - Actions
+
+    private func initialize() async {
+        savedAPIKey = KeychainStore.loadN8nAPIKey(serverID: context.serverID)
+        guard savedAPIKey != nil else { return }
+        await openTunnelAndConnect()
+    }
+
+    private func openTunnelAndConnect() async {
+        guard let apiKey = savedAPIKey else { return }
+        tunnelError = nil
+        do {
+            let url = try await serverManager.pluginTunnelURL(
+                for: context.serverID,
+                remotePort: n8nPort
+            )
+            let c = N8nClient(baseURL: url, apiKey: apiKey)
+            client = c
+            await loadData(with: c)
+        } catch {
+            tunnelError = "Cannot reach n8n: \(error.localizedDescription)"
+        }
+    }
+
+    private func saveAPIKey() async {
+        let trimmed = apiKeyInput.trimmingCharacters(in: .whitespaces)
+        guard !trimmed.isEmpty else { return }
+
+        isSavingKey = true
+        keySetupError = nil
+        defer { isSavingKey = false }
+
+        do {
+            let url = try await serverManager.pluginTunnelURL(
+                for: context.serverID,
+                remotePort: n8nPort
+            )
+            let tempClient = N8nClient(baseURL: url, apiKey: trimmed)
+            _ = try await tempClient.fetchWorkflows()  // verify key works
+
+            try KeychainStore.saveN8nAPIKey(trimmed, serverID: context.serverID)
+            savedAPIKey = trimmed
+            client = tempClient
+            await loadData(with: tempClient)
+        } catch {
+            keySetupError = error.localizedDescription
+        }
+    }
+
+    private func loadData(with c: N8nClient) async {
+        isLoading = true
+        loadError = nil
+        defer { isLoading = false }
+        do {
+            async let wf = c.fetchWorkflows()
+            async let ex = c.fetchExecutions()
+            async let running = c.fetchRunningExecutions()
+            let (newWorkflows, recent, active) = try await (wf, ex, running)
+            workflows = newWorkflows
+            // Active executions first, then recent history; deduplicate by ID
+            var seen = Set<String>()
+            executions = (active + recent).filter { seen.insert($0.id).inserted }
+        } catch {
+            loadError = error.localizedDescription
+        }
+    }
+
+    private func loadWebhookInfo(for workflowID: String, client c: N8nClient) async {
+        isLoadingWebhookInfo = true
+        defer { isLoadingWebhookInfo = false }
+        webhookInfo = try? await c.fetchWebhookInfo(workflowID: workflowID)
+    }
+
+    private func triggerWorkflow(with c: N8nClient) async {
+        guard let info = webhookInfo else { return }
+
+        isTriggering = true
+        triggerMessage = nil
+        defer { isTriggering = false }
+
+        do {
+            try await c.triggerWebhook(path: info.path, method: info.method)
+            triggerMessage = "Triggered successfully"
+            try? await Task.sleep(for: .seconds(1))
+            await loadData(with: c)
+        } catch {
+            triggerMessage = "Error: \(error.localizedDescription)"
+        }
+    }
+
+    private func requirementRow(_ text: LocalizedStringKey) -> some View {
+        HStack(alignment: .top, spacing: 6) {
+            Image(systemName: "checkmark")
+                .font(.caption2.weight(.semibold))
+                .foregroundStyle(Theme.healthy)
+                .frame(width: 12)
+            Text(text)
+                .font(.caption)
+                .foregroundStyle(.secondary)
+        }
+    }
+}
+
+// MARK: - N8nExecution status helpers
+
+private extension N8nExecution {
+    var statusIcon: String {
+        switch status {
+        case "success": "checkmark.circle.fill"
+        case "error", "crashed": "xmark.circle.fill"
+        case "running": "arrow.triangle.2.circlepath"
+        case "waiting": "clock.fill"
+        default: "circle"
+        }
+    }
+
+    var statusColor: Color {
+        switch status {
+        case "success": Theme.healthy
+        case "error", "crashed": Theme.critical
+        case "running": Theme.accent
+        case "waiting": Theme.warning
+        default: .secondary
+        }
+    }
+}

--- a/deskmon/Plugins/N8nPlugin/N8nPlugin.swift
+++ b/deskmon/Plugins/N8nPlugin/N8nPlugin.swift
@@ -1,0 +1,14 @@
+import SwiftUI
+
+struct N8nPlugin: ContainerPlugin {
+    let id = "n8n"
+
+    func matches(imageName: String) -> Bool {
+        // Matches "n8nio/n8n", "docker.n8n.io/n8nio/n8n", "n8n", "custom/n8n", etc.
+        imageName.contains("n8n")
+    }
+
+    func makeDetailView(context: PluginContext) -> AnyView {
+        AnyView(N8nDetailView(context: context))
+    }
+}

--- a/deskmon/Plugins/PluginRegistry.swift
+++ b/deskmon/Plugins/PluginRegistry.swift
@@ -1,0 +1,28 @@
+import Foundation
+
+/// Singleton registry that maps Docker container images to their plugins.
+///
+/// Register plugins once at app startup from `deskmonApp.init()`.
+@MainActor
+final class PluginRegistry {
+    static let shared = PluginRegistry()
+
+    private var plugins: [any ContainerPlugin] = []
+
+    private init() {}
+
+    /// Register a plugin. Silently ignores duplicates (same `id`).
+    func register(_ plugin: any ContainerPlugin) {
+        guard !plugins.contains(where: { $0.id == plugin.id }) else { return }
+        plugins.append(plugin)
+    }
+
+    /// Return the first registered plugin whose `matches(imageName:)` returns `true`,
+    /// or `nil` if no plugin handles the image.
+    func plugin(for imageName: String) -> (any ContainerPlugin)? {
+        // Normalise: lowercase, strip tag (everything after the first ":")
+        let normalized = imageName.lowercased()
+            .components(separatedBy: ":").first ?? imageName.lowercased()
+        return plugins.first { $0.matches(imageName: normalized) }
+    }
+}

--- a/deskmon/Services/ServerManager.swift
+++ b/deskmon/Services/ServerManager.swift
@@ -3,6 +3,17 @@ import Foundation
 import os
 import SwiftUI
 
+// Codable snapshot of the fields that need to survive across launches.
+private struct ServerConfig: Codable {
+    let id: UUID
+    let name: String
+    let host: String
+    let username: String
+    let sshPort: Int
+    let agentPort: Int
+    let hasKeyInstalled: Bool
+}
+
 @MainActor
 @Observable
 final class ServerManager {
@@ -12,6 +23,8 @@ final class ServerManager {
     var alertManager: AlertManager?
 
     private static let log = Logger(subsystem: "prowlsh.deskmon", category: "ServerManager")
+    private static let serversKey = "savedServers"
+    private static let selectedIDKey = "selectedServerID"
     private let client = AgentClient.shared
     private var sshManagers: [UUID: SSHManager] = [:]
     private var streamTasks: [UUID: Task<Void, Never>] = [:]
@@ -27,6 +40,38 @@ final class ServerManager {
     /// The tunnel base URL for the selected server (used by views for actions).
     private func baseURL(for server: ServerInfo) -> String? {
         sshManagers[server.id]?.tunnelBaseURL
+    }
+
+    // MARK: - Persistence
+
+    init() {
+        if let data = UserDefaults.standard.data(forKey: Self.serversKey),
+           let configs = try? JSONDecoder().decode([ServerConfig].self, from: data) {
+            servers = configs.map {
+                ServerInfo(id: $0.id, name: $0.name, host: $0.host, username: $0.username,
+                           sshPort: $0.sshPort, agentPort: $0.agentPort, hasKeyInstalled: $0.hasKeyInstalled)
+            }
+        }
+        if let data = UserDefaults.standard.data(forKey: Self.selectedIDKey),
+           let id = try? JSONDecoder().decode(UUID.self, from: data),
+           servers.contains(where: { $0.id == id }) {
+            selectedServerID = id
+        } else {
+            selectedServerID = servers.first?.id
+        }
+    }
+
+    private func saveToDisk() {
+        let configs = servers.map {
+            ServerConfig(id: $0.id, name: $0.name, host: $0.host, username: $0.username,
+                         sshPort: $0.sshPort, agentPort: $0.agentPort, hasKeyInstalled: $0.hasKeyInstalled)
+        }
+        if let data = try? JSONEncoder().encode(configs) {
+            UserDefaults.standard.set(data, forKey: Self.serversKey)
+        }
+        if let data = try? JSONEncoder().encode(selectedServerID) {
+            UserDefaults.standard.set(data, forKey: Self.selectedIDKey)
+        }
     }
 
     // MARK: - SSH Connection
@@ -73,6 +118,53 @@ final class ServerManager {
         startStream(for: server)
 
         // Background: generate and install SSH key
+        Task {
+            await installSSHKey(for: server, ssh: ssh)
+        }
+    }
+
+    /// Connect to a server using SSH key file data for authentication.
+    /// Called from AddServerSheet when the user selects an SSH key file.
+    func connectServer(_ server: ServerInfo, keyData: Data, passphrase: String? = nil) async throws {
+        let ssh = SSHManager()
+        sshManagers[server.id] = ssh
+
+        server.connectionPhase = .sshConnecting
+
+        // Parse the OpenSSH private key from file data (handles encrypted keys via passphrase)
+        let privateKey = try SSHKeyGenerator.parsePrivateKey(from: keyData, passphrase: passphrase)
+
+        // SSH connect with key
+        try await ssh.connect(
+            host: server.host,
+            port: server.sshPort,
+            username: server.username,
+            privateKey: privateKey
+        )
+
+        // Open tunnel
+        try await ssh.openTunnel(remotePort: server.agentPort)
+        server.connectionPhase = .tunnelOpen
+
+        // Verify agent is reachable through tunnel
+        guard let url = ssh.tunnelBaseURL else {
+            throw SSHTunnelError.notConnected
+        }
+
+        let response = try await client.fetchStats(baseURL: url)
+        applyFullSnapshot(server: server, response: response)
+
+        // Wire disconnect handler
+        ssh.onDisconnect { [weak self] in
+            Task { @MainActor [weak self] in
+                self?.handleSSHDisconnect(serverID: server.id)
+            }
+        }
+
+        // Start SSE stream
+        startStream(for: server)
+
+        // Background: generate and install SSH key for future reconnects
         Task {
             await installSSHKey(for: server, ssh: ssh)
         }
@@ -366,6 +458,7 @@ final class ServerManager {
             try await SSHKeyGenerator.installPublicKey(on: ssh, authorizedKeysLine: keyPair.authorizedKeysLine)
             try KeychainStore.savePrivateKey(keyPair.privateKeyData, for: server.id)
             server.hasKeyInstalled = true
+            saveToDisk()
             Self.log.info("SSH key installed for \(server.name)")
         } catch {
             Self.log.error("SSH key install failed for \(server.name): \(error.localizedDescription)")
@@ -380,6 +473,7 @@ final class ServerManager {
         if selectedServerID == nil {
             selectedServerID = server.id
         }
+        saveToDisk()
         return server
     }
 
@@ -390,6 +484,7 @@ final class ServerManager {
         server.host = host
         server.username = username
         server.sshPort = sshPort
+        saveToDisk()
 
         if connectionChanged {
             // Disconnect and reconnect with new settings
@@ -413,11 +508,13 @@ final class ServerManager {
         if selectedServerID == server.id {
             selectedServerID = servers.first?.id
         }
+        saveToDisk()
     }
 
     func selectServer(_ server: ServerInfo) {
         selectedServerID = server.id
         isConnected = server.status != .offline && server.status != .unauthorized
+        saveToDisk()
     }
 
     // MARK: - Server Actions
@@ -453,6 +550,26 @@ final class ServerManager {
         guard let server = selectedServer,
               let url = baseURL(for: server) else { throw AgentError.invalidURL }
         return try await client.restartAgent(baseURL: url)
+    }
+
+    /// Open (or reuse) an SSH tunnel to a remote service port for the given server.
+    /// Used by container plugins to reach services running alongside the deskmon agent.
+    func pluginTunnelURL(for serverID: UUID, remotePort: Int) async throws -> String {
+        guard let ssh = sshManagers[serverID] else { throw SSHTunnelError.notConnected }
+        return try await ssh.openExtraTunnel(remotePort: remotePort)
+    }
+
+    /// Execute a shell command on the given server over SSH and return its stdout.
+    func executeCommand(_ command: String, on serverID: UUID) async throws -> String {
+        guard let ssh = sshManagers[serverID] else { throw SSHTunnelError.notConnected }
+        return try await ssh.executeCommand(command)
+    }
+
+    /// Execute a shell command on the currently selected server over SSH and return its stdout.
+    func executeCommand(_ command: String) async throws -> String {
+        guard let server = selectedServer,
+              let ssh = sshManagers[server.id] else { throw SSHTunnelError.notConnected }
+        return try await ssh.executeCommand(command)
     }
 
     // MARK: - Status Derivation

--- a/deskmon/Views/Components/ContainerDetailView.swift
+++ b/deskmon/Views/Components/ContainerDetailView.swift
@@ -8,6 +8,7 @@ struct ContainerDetailView: View {
     @State private var showStopConfirmation = false
     @State private var showRestartConfirmation = false
     @State private var actionError: String?
+    @State private var showingLogs = false
 
     var body: some View {
         ScrollView {
@@ -20,6 +21,13 @@ struct ContainerDetailView: View {
                     portMappingsSection
                     networkSection
                     diskIOSection
+                }
+                if container.status == .running,
+                   let plugin = PluginRegistry.shared.plugin(for: container.image),
+                   let serverID = serverManager.selectedServerID {
+                    plugin.makeDetailView(
+                        context: PluginContext(serverID: serverID, container: container)
+                    )
                 }
             }
             .padding(16)
@@ -98,6 +106,14 @@ struct ContainerDetailView: View {
                         showRestartConfirmation = true
                     }
                 }
+
+                Spacer()
+
+                Button { showingLogs = true } label: {
+                    Label("Logs", systemImage: "doc.text")
+                }
+                .buttonStyle(.dark)
+                .font(.caption.weight(.medium))
             }
 
             if let actionError {
@@ -108,6 +124,9 @@ struct ContainerDetailView: View {
         }
         .padding(12)
         .tintedCardStyle(cornerRadius: 10, tint: Theme.accent)
+        .sheet(isPresented: $showingLogs) {
+            ContainerLogView(container: container)
+        }
     }
 
     private func actionButton(_ label: String, systemImage: String, color: Color, action: ContainerAction, onTap: @escaping () -> Void) -> some View {

--- a/deskmon/Views/Components/ContainerLogView.swift
+++ b/deskmon/Views/Components/ContainerLogView.swift
@@ -1,0 +1,136 @@
+import SwiftUI
+
+struct ContainerLogView: View {
+    let container: DockerContainer
+
+    @Environment(ServerManager.self) private var serverManager
+    @Environment(\.dismiss) private var dismiss
+
+    @State private var logs = ""
+    @State private var isLoading = false
+    @State private var loadError: String?
+    @State private var autoRefresh = true
+    @State private var refreshTask: Task<Void, Never>?
+
+    var body: some View {
+        VStack(spacing: 0) {
+            // Header
+            HStack(spacing: 12) {
+                Circle()
+                    .fill(container.status.color)
+                    .frame(width: 8, height: 8)
+
+                Text(container.name)
+                    .font(.headline)
+
+                Spacer()
+
+                if isLoading {
+                    ProgressView()
+                        .controlSize(.small)
+                }
+
+                Button {
+                    autoRefresh.toggle()
+                } label: {
+                    Label(autoRefresh ? "Pause" : "Resume", systemImage: autoRefresh ? "pause.fill" : "play.fill")
+                        .font(.caption.weight(.medium))
+                }
+                .buttonStyle(.dark)
+
+                Button { dismiss() } label: {
+                    Image(systemName: "xmark")
+                        .font(.caption.weight(.bold))
+                        .foregroundStyle(.secondary)
+                }
+                .buttonStyle(.plain)
+            }
+            .padding(.horizontal, 16)
+            .padding(.vertical, 12)
+            .background(Theme.cardBackground)
+            .overlay(alignment: .bottom) {
+                Divider().background(Theme.cardBorder)
+            }
+
+            // Log content
+            if let error = loadError, logs.isEmpty {
+                VStack(spacing: 10) {
+                    Image(systemName: "exclamationmark.triangle")
+                        .font(.system(size: 32))
+                        .foregroundStyle(Theme.warning)
+                    Text("Failed to load logs")
+                        .font(.headline)
+                    Text(error)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                        .multilineTextAlignment(.center)
+                }
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+            } else {
+                ScrollViewReader { proxy in
+                    ScrollView {
+                        VStack(alignment: .leading, spacing: 0) {
+                            Text(logs.isEmpty ? "Loading…" : logs)
+                                .font(.caption.monospaced())
+                                .foregroundStyle(logs.isEmpty ? Color.secondary : Color.primary)
+                                .textSelection(.enabled)
+                                .frame(maxWidth: .infinity, alignment: .leading)
+                                .padding(12)
+
+                            Color.clear
+                                .frame(height: 1)
+                                .id("bottom")
+                        }
+                    }
+                    .background(Color.black)
+                    .onChange(of: logs) {
+                        if autoRefresh {
+                            proxy.scrollTo("bottom", anchor: .bottom)
+                        }
+                    }
+                }
+            }
+        }
+        .frame(minWidth: 600, idealWidth: 720, minHeight: 400, idealHeight: 560)
+        .preferredColorScheme(.dark)
+        .task { startRefreshLoop() }
+        .onChange(of: autoRefresh) {
+            if autoRefresh {
+                startRefreshLoop()
+            } else {
+                refreshTask?.cancel()
+                refreshTask = nil
+            }
+        }
+        .onDisappear {
+            refreshTask?.cancel()
+        }
+    }
+
+    // MARK: - Refresh Loop
+
+    private func startRefreshLoop() {
+        refreshTask?.cancel()
+        refreshTask = Task {
+            while !Task.isCancelled && autoRefresh {
+                await fetchLogs()
+                guard !Task.isCancelled else { break }
+                try? await Task.sleep(for: .seconds(10))
+            }
+        }
+    }
+
+    private func fetchLogs() async {
+        isLoading = true
+        do {
+            let output = try await serverManager.executeCommand(
+                "docker logs --tail 100 \(container.id) 2>&1"
+            )
+            loadError = nil
+            logs = output
+        } catch {
+            loadError = error.localizedDescription
+        }
+        isLoading = false
+    }
+}

--- a/deskmon/Views/Components/SecurityPanelView.swift
+++ b/deskmon/Views/Components/SecurityPanelView.swift
@@ -1,0 +1,439 @@
+import SwiftUI
+
+// MARK: - Data Model
+
+private struct SecurityData {
+    var firewallStatus: String?
+    var unattendedUpgrades: String?
+    var fail2banOutput: String?
+    var pendingSecurityUpdates: Int?
+    var failedLogins: [String] = []
+    var sshPasswordAuth: String?
+    var sshRootLogin: String?
+    var appArmorStatus: String?
+}
+
+// MARK: - Main View
+
+struct SecurityPanelView: View {
+    let serverID: UUID
+
+    @Environment(ServerManager.self) private var serverManager
+    @State private var data = SecurityData()
+    @State private var isLoading = false
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            HStack {
+                Text("Security")
+                    .font(.subheadline.weight(.semibold))
+                    .foregroundStyle(.secondary)
+                Spacer()
+                Button {
+                    Task { await fetchData() }
+                } label: {
+                    Image(systemName: isLoading ? "arrow.triangle.2.circlepath" : "arrow.clockwise")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                        .symbolEffect(.rotate, isActive: isLoading)
+                }
+                .buttonStyle(.plain)
+                .disabled(isLoading)
+            }
+            .padding(.horizontal, 4)
+
+            VStack(spacing: 0) {
+                SecurityRowView(
+                    label: "Firewall (UFW)",
+                    value: firewallLabel,
+                    color: firewallColor,
+                    info: .init(
+                        description: "Controls inbound/outbound network traffic. An inactive firewall exposes all ports to the internet.",
+                        fixCommand: firewallFixCommand
+                    )
+                )
+
+                Divider().background(Theme.cardBorder)
+
+                SecurityRowView(
+                    label: "Unattended Upgrades",
+                    value: upgradesLabel,
+                    color: upgradesColor,
+                    info: .init(
+                        description: "Automatically installs security patches without manual intervention, keeping the system protected against known CVEs.",
+                        fixCommand: upgradesFixCommand
+                    )
+                )
+
+                Divider().background(Theme.cardBorder)
+
+                SecurityRowView(
+                    label: "Fail2Ban",
+                    value: fail2banLabel,
+                    color: fail2banColor,
+                    info: .init(
+                        description: "Monitors log files and automatically bans IPs with repeated failed login attempts, protecting against brute-force attacks.",
+                        fixCommand: fail2banFixCommand
+                    )
+                )
+
+                Divider().background(Theme.cardBorder)
+
+                SecurityRowView(
+                    label: "Security Updates",
+                    value: updatesLabel,
+                    color: updatesColor,
+                    info: .init(
+                        description: "Packages with outstanding CVE security patches available. Apply promptly to reduce exposure to known vulnerabilities.",
+                        fixCommand: updatesFixCommand
+                    )
+                )
+
+                Divider().background(Theme.cardBorder)
+
+                SecurityRowView(
+                    label: "SSH Password Auth",
+                    value: sshPasswordAuthLabel,
+                    color: sshPasswordAuthColor,
+                    info: .init(
+                        description: "Password-based SSH authentication is vulnerable to brute-force attacks. Key-based authentication is strongly recommended.",
+                        fixCommand: sshPasswordAuthFixCommand
+                    )
+                )
+
+                Divider().background(Theme.cardBorder)
+
+                SecurityRowView(
+                    label: "SSH Root Login",
+                    value: sshRootLoginLabel,
+                    color: sshRootLoginColor,
+                    info: .init(
+                        description: "Allowing direct root SSH login bypasses audit trails and increases attack surface. Use a regular user with sudo instead.",
+                        fixCommand: sshRootLoginFixCommand
+                    )
+                )
+
+                Divider().background(Theme.cardBorder)
+
+                SecurityRowView(
+                    label: "AppArmor",
+                    value: appArmorLabel,
+                    color: appArmorColor,
+                    info: .init(
+                        description: "Mandatory access control system that confines programs to a limited set of resources, limiting damage from compromised processes.",
+                        fixCommand: appArmorFixCommand
+                    )
+                )
+
+                if !data.failedLogins.isEmpty {
+                    Divider().background(Theme.cardBorder)
+
+                    VStack(alignment: .leading, spacing: 6) {
+                        HStack {
+                            Text("Recent Failed SSH Logins")
+                                .font(.caption2.weight(.medium))
+                                .foregroundStyle(.secondary)
+                            InfoButton(info: .init(
+                                description: "A high volume of failed logins may indicate a brute-force attack in progress. Fail2Ban can automatically block repeat offenders.",
+                                fixCommand: nil
+                            ))
+                            Spacer()
+                        }
+
+                        VStack(alignment: .leading, spacing: 3) {
+                            ForEach(data.failedLogins, id: \.self) { line in
+                                Text(line)
+                                    .font(.caption2.monospaced())
+                                    .foregroundStyle(.tertiary)
+                                    .lineLimit(1)
+                            }
+                        }
+                    }
+                    .padding(.horizontal, 12)
+                    .padding(.vertical, 8)
+                }
+            }
+            .cardStyle(cornerRadius: 10)
+        }
+        .task { await fetchData() }
+    }
+
+    // MARK: - Labels & Colors
+
+    private var firewallLabel: String {
+        guard let s = data.firewallStatus else { return "N/A" }
+        return s.localizedCaseInsensitiveContains("active") ? "Active" : "Inactive"
+    }
+    private var firewallColor: Color {
+        guard let s = data.firewallStatus else { return .secondary }
+        return s.localizedCaseInsensitiveContains("active") ? Theme.healthy : Theme.warning
+    }
+    private var firewallFixCommand: String? {
+        guard let s = data.firewallStatus, s.localizedCaseInsensitiveContains("active") else {
+            return "sudo ufw allow ssh && sudo ufw enable"
+        }
+        return nil
+    }
+
+    private var upgradesLabel: String {
+        guard let s = data.unattendedUpgrades else { return "N/A" }
+        return s.trimmingCharacters(in: .whitespacesAndNewlines).capitalized
+    }
+    private var upgradesColor: Color {
+        guard let s = data.unattendedUpgrades else { return .secondary }
+        return s.localizedCaseInsensitiveContains("enabled") ? Theme.healthy : Theme.warning
+    }
+    private var upgradesFixCommand: String? {
+        guard let s = data.unattendedUpgrades, s.localizedCaseInsensitiveContains("enabled") else {
+            return "sudo apt install unattended-upgrades -y && sudo dpkg-reconfigure -plow unattended-upgrades"
+        }
+        return nil
+    }
+
+    private var fail2banLabel: String {
+        guard let s = data.fail2banOutput else { return "N/A" }
+        if s.localizedCaseInsensitiveContains("Number of jails"),
+           let range = s.range(of: #"Number of jails:\s*(\d+)"#, options: .regularExpression),
+           let numRange = s[range].range(of: #"\d+"#, options: .regularExpression) {
+            let count = String(s[range][numRange])
+            return "\(count) jail\(count == "1" ? "" : "s")"
+        }
+        return s.localizedCaseInsensitiveContains("fail2ban") ? "Active" : "N/A"
+    }
+    private var fail2banColor: Color {
+        guard let s = data.fail2banOutput else { return .secondary }
+        return s.localizedCaseInsensitiveContains("jail") || s.localizedCaseInsensitiveContains("fail2ban") ? Theme.healthy : Theme.warning
+    }
+    private var fail2banFixCommand: String? {
+        guard let s = data.fail2banOutput,
+              s.localizedCaseInsensitiveContains("jail") || s.localizedCaseInsensitiveContains("fail2ban") else {
+            return "sudo apt install fail2ban -y && sudo systemctl enable --now fail2ban"
+        }
+        return nil
+    }
+
+    private var updatesLabel: String {
+        guard let n = data.pendingSecurityUpdates else { return "N/A" }
+        return n == 0 ? "Up to date" : "\(n) pending"
+    }
+    private var updatesColor: Color {
+        guard let n = data.pendingSecurityUpdates else { return .secondary }
+        if n == 0 { return Theme.healthy }
+        if n <= 5 { return Theme.warning }
+        return Theme.critical
+    }
+    private var updatesFixCommand: String? {
+        guard let n = data.pendingSecurityUpdates, n > 0 else { return nil }
+        return "sudo apt-get upgrade -y"
+    }
+
+    private var sshPasswordAuthLabel: String {
+        guard let s = data.sshPasswordAuth, !s.isEmpty else { return "N/A" }
+        if s.localizedCaseInsensitiveContains("no") { return "Disabled" }
+        if s.localizedCaseInsensitiveContains("yes") { return "Enabled" }
+        return "N/A"
+    }
+    private var sshPasswordAuthColor: Color {
+        guard let s = data.sshPasswordAuth, !s.isEmpty else { return .secondary }
+        if s.localizedCaseInsensitiveContains("no") { return Theme.healthy }
+        if s.localizedCaseInsensitiveContains("yes") { return Theme.critical }
+        return .secondary
+    }
+    private var sshPasswordAuthFixCommand: String? {
+        guard let s = data.sshPasswordAuth, s.localizedCaseInsensitiveContains("yes") else { return nil }
+        return "sudo sed -i 's/^PasswordAuthentication yes/PasswordAuthentication no/' /etc/ssh/sshd_config && sudo systemctl reload sshd"
+    }
+
+    private var sshRootLoginLabel: String {
+        guard let s = data.sshRootLogin, !s.isEmpty else { return "N/A" }
+        if s.localizedCaseInsensitiveContains("prohibit-password") { return "Key-only" }
+        if s.localizedCaseInsensitiveContains("no") { return "Disabled" }
+        if s.localizedCaseInsensitiveContains("yes") { return "Enabled" }
+        return "N/A"
+    }
+    private var sshRootLoginColor: Color {
+        guard let s = data.sshRootLogin, !s.isEmpty else { return .secondary }
+        if s.localizedCaseInsensitiveContains("prohibit-password") { return Theme.warning }
+        if s.localizedCaseInsensitiveContains("no") { return Theme.healthy }
+        if s.localizedCaseInsensitiveContains("yes") { return Theme.critical }
+        return .secondary
+    }
+    private var sshRootLoginFixCommand: String? {
+        guard let s = data.sshRootLogin, s.localizedCaseInsensitiveContains("yes") else { return nil }
+        return "sudo sed -i 's/^PermitRootLogin yes/PermitRootLogin no/' /etc/ssh/sshd_config && sudo systemctl reload sshd"
+    }
+
+    private var appArmorLabel: String {
+        guard let s = data.appArmorStatus, !s.isEmpty else { return "N/A" }
+        return s.trimmingCharacters(in: .whitespacesAndNewlines).capitalized
+    }
+    private var appArmorColor: Color {
+        guard let s = data.appArmorStatus, !s.isEmpty else { return .secondary }
+        return s.localizedCaseInsensitiveContains("active") ? Theme.healthy : Theme.warning
+    }
+    private var appArmorFixCommand: String? {
+        guard let s = data.appArmorStatus, s.localizedCaseInsensitiveContains("active") else {
+            return "sudo apt install apparmor -y && sudo systemctl enable --now apparmor"
+        }
+        return nil
+    }
+
+    // MARK: - Fetch
+
+    private func fetchData() async {
+        isLoading = true
+        defer { isLoading = false }
+
+        async let firewall = try? await serverManager.executeCommand(
+            "ufw status 2>/dev/null | head -1", on: serverID
+        )
+        async let upgrades = try? await serverManager.executeCommand(
+            "systemctl is-enabled unattended-upgrades 2>/dev/null", on: serverID
+        )
+        async let fail2ban = try? await serverManager.executeCommand(
+            "fail2ban-client status 2>/dev/null | head -4", on: serverID
+        )
+        async let secUpdates = try? await serverManager.executeCommand(
+            "apt list --upgradable 2>/dev/null | grep -ic security; true", on: serverID
+        )
+        async let logins = try? await serverManager.executeCommand(
+            #"journalctl _SYSTEMD_UNIT=sshd.service --no-pager -n 50 2>/dev/null | grep "Failed" | tail -5"#,
+            on: serverID
+        )
+        async let sshPasswordAuth = try? await serverManager.executeCommand(
+            "grep -E '^PasswordAuthentication' /etc/ssh/sshd_config 2>/dev/null | awk '{print $2}'",
+            on: serverID
+        )
+        async let sshRootLogin = try? await serverManager.executeCommand(
+            "grep -E '^PermitRootLogin' /etc/ssh/sshd_config 2>/dev/null | awk '{print $2}'",
+            on: serverID
+        )
+        async let appArmor = try? await serverManager.executeCommand(
+            "systemctl is-active apparmor 2>/dev/null", on: serverID
+        )
+
+        let (fw, ug, f2b, upd, lg, spa, srl, aa) = await (
+            firewall, upgrades, fail2ban, secUpdates, logins, sshPasswordAuth, sshRootLogin, appArmor
+        )
+
+        data.firewallStatus        = fw?.trimmingCharacters(in: .whitespacesAndNewlines)
+        data.unattendedUpgrades    = ug?.trimmingCharacters(in: .whitespacesAndNewlines)
+        data.fail2banOutput        = f2b?.trimmingCharacters(in: .whitespacesAndNewlines)
+        data.pendingSecurityUpdates = upd.flatMap { Int($0.trimmingCharacters(in: .whitespacesAndNewlines)) }
+        data.failedLogins = lg?
+            .components(separatedBy: "\n")
+            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+            .filter { !$0.isEmpty } ?? []
+        data.sshPasswordAuth = spa?.trimmingCharacters(in: .whitespacesAndNewlines)
+        data.sshRootLogin    = srl?.trimmingCharacters(in: .whitespacesAndNewlines)
+        data.appArmorStatus  = aa?.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+}
+
+// MARK: - Row View
+
+private struct SecurityRowView: View {
+    struct Info {
+        let description: String
+        let fixCommand: String?
+    }
+
+    let label: String
+    let value: String
+    let color: Color
+    let info: Info
+
+    var body: some View {
+        HStack(spacing: 10) {
+            Circle()
+                .fill(color)
+                .frame(width: 7, height: 7)
+            Text(label)
+                .font(.caption)
+            InfoButton(info: info)
+            Spacer()
+            Text(value)
+                .font(.caption.weight(.medium))
+                .foregroundStyle(color)
+        }
+        .padding(.horizontal, 12)
+        .padding(.vertical, 8)
+    }
+}
+
+// MARK: - Info Button
+
+private struct InfoButton: View {
+    let info: SecurityRowView.Info
+    @State private var showing = false
+
+    var body: some View {
+        Button { showing = true } label: {
+            Image(systemName: "info.circle")
+                .font(.caption2)
+                .foregroundStyle(.tertiary)
+        }
+        .buttonStyle(.plain)
+        .popover(isPresented: $showing, arrowEdge: .trailing) {
+            InfoPopoverContent(info: info)
+        }
+    }
+}
+
+// MARK: - Popover Content
+
+private struct InfoPopoverContent: View {
+    let info: SecurityRowView.Info
+    @State private var copied = false
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            Text(info.description)
+                .font(.caption)
+                .foregroundStyle(.secondary)
+                .fixedSize(horizontal: false, vertical: true)
+
+            if let cmd = info.fixCommand {
+                Divider()
+
+                VStack(alignment: .leading, spacing: 6) {
+                    Text("Suggested Fix")
+                        .font(.caption2.weight(.semibold))
+                        .foregroundStyle(.secondary)
+
+                    HStack(alignment: .top, spacing: 8) {
+                        Text(cmd)
+                            .font(.caption2.monospaced())
+                            .foregroundStyle(.primary)
+                            .textSelection(.enabled)
+                            .fixedSize(horizontal: false, vertical: true)
+
+                        Button {
+                            NSPasteboard.general.clearContents()
+                            NSPasteboard.general.setString(cmd, forType: .string)
+                            copied = true
+                            Task {
+                                try? await Task.sleep(for: .seconds(2))
+                                copied = false
+                            }
+                        } label: {
+                            Image(systemName: copied ? "checkmark" : "doc.on.doc")
+                                .font(.caption2)
+                                .foregroundStyle(copied ? Theme.healthy : .secondary)
+                        }
+                        .buttonStyle(.plain)
+                    }
+                    .padding(8)
+                    .background(Color.black.opacity(0.4), in: RoundedRectangle(cornerRadius: 6))
+                    .overlay(
+                        RoundedRectangle(cornerRadius: 6)
+                            .strokeBorder(Theme.cardBorder, lineWidth: 1)
+                    )
+                }
+            }
+        }
+        .padding(14)
+        .frame(width: 300)
+        .preferredColorScheme(.dark)
+    }
+}

--- a/deskmon/deskmonApp.swift
+++ b/deskmon/deskmonApp.swift
@@ -6,6 +6,10 @@ struct deskmonApp: App {
     @State private var lockManager = AppLockManager()
     @State private var alertManager = AlertManager()
 
+    init() {
+        PluginRegistry.shared.register(N8nPlugin())
+    }
+
     var body: some Scene {
         MenuBarExtra {
             DashboardView()
@@ -15,6 +19,7 @@ struct deskmonApp: App {
                 .task {
                     serverManager.alertManager = alertManager
                     alertManager.requestPermissionIfNeeded()
+                    serverManager.startStreaming()
                 }
         } label: {
             MenuBarLabel(status: serverManager.currentStatus)


### PR DESCRIPTION
## Summary

Three related additions that extend what deskmon shows for a connected server, plus a plugin system for adding container-specific detail panels without modifying core files.

### Security Panel
A new read-only card in the main dashboard showing the security posture of the selected server:

| Row | Command | Color logic |
|-----|---------|-------------|
| UFW Firewall | `ufw status` | green = active, amber = inactive |
| Unattended Upgrades | `systemctl is-enabled unattended-upgrades` | green = enabled |
| Fail2Ban | `fail2ban-client status` | green = active |
| Pending security updates | `apt list --upgradable \| grep -ic security` | green = 0, amber = 1–5, red > 5 |
| SSH Password Auth | `grep PasswordAuthentication /etc/ssh/sshd_config` | green = no |
| SSH Root Login | `grep PermitRootLogin /etc/ssh/sshd_config` | green = prohibit-password/no |
| AppArmor | `systemctl is-active apparmor` | green = active |

All commands run concurrently via `async let` over the existing SSH tunnel. Missing tools (e.g. Fail2Ban not installed) show "N/A" gracefully. Each row has an ⓘ popover with a description and a copy-able fix command.

### Container Log Viewer
A "Logs" button in the Container Detail inspector opens a sheet showing the last 100 lines of `docker logs <id> 2>&1`. Auto-refreshes every 10 seconds with a pause/play toggle.

### Plugin architecture
A `ContainerPlugin` protocol + `PluginRegistry` singleton lets you add container-specific detail panels without editing core files. The n8n plugin (already in this fork) is included as a working reference — it opens an extra SSH tunnel to port 5678 and shows workflows, recent executions, and a trigger button.

### Inspector panel improvements
- Switch the detail sidebar from a plain `HStack` to SwiftUI's `.inspector()` modifier so the panel is resizable via a drag handle
- Persist and restore the user's chosen inspector width across app restarts via `UserDefaults`
- Fix: SwiftUI's `.inspector()` always opens at `min` width, ignoring `ideal`; worked around by briefly pinning `min = ideal` in the same state update that selects a container, then resetting after 150 ms

## Test plan

- [ ] Security Panel appears in the live server view; all rows populate after ~1 second
- [ ] Rows where the tool isn't installed show "N/A" without crashing
- [ ] ⓘ popovers show description and a one-click copy button for the fix command
- [ ] "Logs" button visible in Container Detail; sheet opens with monospaced output
- [ ] Logs auto-refresh every 10 s; Pause stops the loop, Play restarts it
- [ ] Drag the inspector handle to resize; close and reopen Dashboard — width is restored
- [ ] Registering a custom `ContainerPlugin` and calling `PluginRegistry.shared.register()` in `deskmonApp.init()` shows the plugin's view in the matching container's detail panel

🤖 Generated with [Claude Code](https://claude.com/claude-code)